### PR TITLE
Removed the JSON encoding again.

### DIFF
--- a/classes/UrlHookJob.php
+++ b/classes/UrlHookJob.php
@@ -131,7 +131,7 @@ class UrlHookJob implements Job {
     $result = new $class($this->url, [
       'method' => $this->method,
       'headers' => $headers,
-      'data' => json_decode($this->body)
+      'data' => $this->body
     ]);
 
     if (!$isKirby3) {

--- a/classes/UrlHookJob.php
+++ b/classes/UrlHookJob.php
@@ -90,7 +90,8 @@ class UrlHookJob implements Job {
   public static function jobForJsonData( string $url, array $data ) : self {
     $instance = new self( $url, 'POST', json_encode( $data, JSON_UNESCAPED_SLASHES ) );
     $instance->headers = array(
-      'Accept' => 'application/json'
+      'Accept' => 'application/json',
+      'Content-Type' => 'application/json'
     );
 
     return $instance;


### PR DESCRIPTION
The URL hook task should not require the usage of JSON data as the body.
It should also be possible so send URL encoded data, or event binary
data.